### PR TITLE
Make sure we have APRSMessageType set when we display the status to the OLED

### DIFF
--- a/src/TaskRouter.cpp
+++ b/src/TaskRouter.cpp
@@ -20,11 +20,10 @@ bool RouterTask::setup(System &system) {
   _beacon_timer.setTimeout(system.getUserConfig()->beacon.timeout * 60 * 1000);
 
   _beaconMsg = std::shared_ptr<APRSMessage>(new APRSMessage());
-  _beaconMsg->setSource(system.getUserConfig()->callsign);
-  _beaconMsg->setDestination("APLG01");
-  String lat = create_lat_aprs(system.getUserConfig()->beacon.positionLatitude);
-  String lng = create_long_aprs(system.getUserConfig()->beacon.positionLongitude);
-  _beaconMsg->getBody()->setData(String("=") + lat + "L" + lng + "&" + system.getUserConfig()->beacon.message);
+  _beaconMsg->decode(system.getUserConfig()->callsign + ">APLG01:=" + 
+    create_lat_aprs(system.getUserConfig()->beacon.positionLatitude) + "L" +
+    create_long_aprs(system.getUserConfig()->beacon.positionLongitude) + "&" +
+    system.getUserConfig()->beacon.message);
 
   return true;
 }


### PR DESCRIPTION
Fixes OLED display of Type:Error when iGate beacons - this was due to beacon message's APRSMessageType not getting set.