### PR TITLE
WiFi on (PoE) Ethernet boards

### DIFF
--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -37,7 +37,7 @@
 	},
 	"lora": {
 		"frequency_rx": 433775000,
-		"gain_rx": 6,
+		"gain_rx": 0,
 		"frequency_tx": 433775000,
 		"power": 20,
 		"spreading_factor": 12,

--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -11,6 +11,7 @@
 	"wifi": {
 		"AP": [
 			{
+		"active": false,
 				"SSID": "YOURSSID",
 				"password": "YOURPASSWORD"
 			}
@@ -36,6 +37,7 @@
 	},
 	"lora": {
 		"frequency_rx": 433775000,
+		"gain_rx": 6;
 		"frequency_tx": 433775000,
 		"power": 20,
 		"spreading_factor": 12,

--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -9,9 +9,9 @@
 		"dns2": "192.0.2.2"
 	},
 	"wifi": {
+		"active": true,
 		"AP": [
 			{
-		"active": false,
 				"SSID": "YOURSSID",
 				"password": "YOURPASSWORD"
 			}
@@ -37,7 +37,7 @@
 	},
 	"lora": {
 		"frequency_rx": 433775000,
-		"gain_rx": 6;
+		"gain_rx": 6,
 		"frequency_tx": 433775000,
 		"power": 20,
 		"spreading_factor": 12,

--- a/lib/LoRa_APRS/LoRa_APRS.cpp
+++ b/lib/LoRa_APRS/LoRa_APRS.cpp
@@ -1,6 +1,6 @@
 #include "LoRa_APRS.h"
 
-LoRa_APRS::LoRa_APRS() : _RxFrequency(433775000), _TxFrequency(433775000), _RxGain(6) {
+LoRa_APRS::LoRa_APRS() : _RxFrequency(433775000), _TxFrequency(433775000) {
 }
 
 bool LoRa_APRS::checkMessage() {
@@ -51,8 +51,7 @@ void LoRa_APRS::setRxFrequency(long frequency) {
 }
 
 void LoRa_APRS::setRxGain(uint8_t gain) {
-  _RxGain = gain;
-  setGain(_RxGain);
+  setGain(gain);
 }
 
 // cppcheck-suppress unusedFunction

--- a/lib/LoRa_APRS/LoRa_APRS.cpp
+++ b/lib/LoRa_APRS/LoRa_APRS.cpp
@@ -1,6 +1,6 @@
 #include "LoRa_APRS.h"
 
-LoRa_APRS::LoRa_APRS() : _RxFrequency(433775000), _TxFrequency(433775000) {
+LoRa_APRS::LoRa_APRS() : _RxFrequency(433775000), _TxFrequency(433775000), _RxGain(6) {
 }
 
 bool LoRa_APRS::checkMessage() {
@@ -48,6 +48,11 @@ void LoRa_APRS::sendMessage(const std::shared_ptr<APRSMessage> msg) {
 void LoRa_APRS::setRxFrequency(long frequency) {
   _RxFrequency = frequency;
   setFrequency(_RxFrequency);
+}
+
+void LoRa_APRS::setRxGain(uint8_t gain) {
+  _RxGain = gain;
+  setGain(_RxGain);
 }
 
 // cppcheck-suppress unusedFunction

--- a/lib/LoRa_APRS/LoRa_APRS.h
+++ b/lib/LoRa_APRS/LoRa_APRS.h
@@ -28,7 +28,6 @@ private:
   std::shared_ptr<APRSMessage> _LastReceivedMsg;
   long                         _RxFrequency;
   long                         _TxFrequency;
-  uint8_t                      _RxGain;
 };
 
 #endif

--- a/lib/LoRa_APRS/LoRa_APRS.h
+++ b/lib/LoRa_APRS/LoRa_APRS.h
@@ -19,6 +19,8 @@ public:
   void setRxFrequency(long frequency);
   long getRxFrequency() const;
 
+  void setRxGain(uint8_t gain);
+
   void setTxFrequency(long frequency);
   long getTxFrequency() const;
 
@@ -26,6 +28,7 @@ private:
   std::shared_ptr<APRSMessage> _LastReceivedMsg;
   long                         _RxFrequency;
   long                         _TxFrequency;
+  uint8_t                      _RxGain;
 };
 
 #endif

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -18,7 +18,7 @@
 #include "TaskWifi.h"
 #include "project_configuration.h"
 
-#define VERSION "21.35.0-dev"
+#define VERSION "21.44.0-dev"
 
 String create_lat_aprs(double lat);
 String create_long_aprs(double lng);
@@ -100,9 +100,10 @@ void setup() {
   LoRaSystem.getTaskManager().addTask(&routerTask);
 
   if (userConfig.aprs_is.active) {
-    if (boardConfig->Type == eETH_BOARD) {
+    if (boardConfig->Type == eETH_BOARD && !userConfig.wifi.active) {
       LoRaSystem.getTaskManager().addAlwaysRunTask(&ethTask);
-    } else {
+    }
+    if (userConfig.wifi.active) {
       LoRaSystem.getTaskManager().addAlwaysRunTask(&wifiTask);
     }
     LoRaSystem.getTaskManager().addTask(&otaTask);

--- a/src/TaskModem.cpp
+++ b/src/TaskModem.cpp
@@ -24,6 +24,7 @@ bool ModemTask::setup(System &system) {
       ;
   }
   _lora_aprs.setRxFrequency(system.getUserConfig()->lora.frequencyRx);
+  _lora_aprs.setRxGain(system.getUserConfig()->lora.gainRx);
   _lora_aprs.setTxFrequency(system.getUserConfig()->lora.frequencyTx);
   _lora_aprs.setTxPower(system.getUserConfig()->lora.power);
   _lora_aprs.setSpreadingFactor(system.getUserConfig()->lora.spreadingFactor);

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -17,7 +17,8 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
     conf.network.dns2.fromString(data["network"]["dns2"].as<String>());
   }
 
-  JsonArray aps = data["wifi"]["AP"].as<JsonArray>();
+  conf.wifi.active = data["wifi"]["active"];
+  JsonArray aps    = data["wifi"]["AP"].as<JsonArray>();
   for (JsonVariant v : aps) {
     Configuration::Wifi::AP ap;
     ap.SSID     = v["SSID"].as<String>();
@@ -39,6 +40,7 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
   conf.digi.active          = data["digi"]["active"] | false;
   conf.digi.beacon          = data["digi"]["beacon"] | false;
   conf.lora.frequencyRx     = data["lora"]["frequency_rx"] | 433775000;
+  conf.lora.gainRx          = data["lora"]["gain_rx"] | 6;
   conf.lora.frequencyTx     = data["lora"]["frequency_tx"] | 433775000;
   conf.lora.power           = data["lora"]["power"] | 20;
   conf.lora.spreadingFactor = data["lora"]["spreading_factor"] | 12;
@@ -82,7 +84,8 @@ void ProjectConfigurationManagement::writeProjectConfiguration(Configuration &co
     data["network"]["dns2"]     = conf.network.dns2.toString();
   }
 
-  JsonArray aps = data["wifi"].createNestedArray("AP");
+  data["wifi"]["active"] = conf.wifi.active;
+  JsonArray aps          = data["wifi"].createNestedArray("AP");
   for (Configuration::Wifi::AP ap : conf.wifi.APs) {
     JsonObject v  = aps.createNestedObject();
     v["SSID"]     = ap.SSID;
@@ -99,6 +102,7 @@ void ProjectConfigurationManagement::writeProjectConfiguration(Configuration &co
   data["digi"]["active"]                  = conf.digi.active;
   data["digi"]["beacon"]                  = conf.digi.beacon;
   data["lora"]["frequency_rx"]            = conf.lora.frequencyRx;
+  data["lora"]["gain_rx"]                 = conf.lora.gainRx;
   data["lora"]["frequency_tx"]            = conf.lora.frequencyTx;
   data["lora"]["power"]                   = conf.lora.power;
   data["lora"]["spreading_factor"]        = conf.lora.spreadingFactor;

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -40,7 +40,7 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
   conf.digi.active          = data["digi"]["active"] | false;
   conf.digi.beacon          = data["digi"]["beacon"] | false;
   conf.lora.frequencyRx     = data["lora"]["frequency_rx"] | 433775000;
-  conf.lora.gainRx          = data["lora"]["gain_rx"] | 6;
+  conf.lora.gainRx          = data["lora"]["gain_rx"] | 0;
   conf.lora.frequencyTx     = data["lora"]["frequency_tx"] | 433775000;
   conf.lora.power           = data["lora"]["power"] | 20;
   conf.lora.spreadingFactor = data["lora"]["spreading_factor"] | 12;

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -21,15 +21,15 @@ public:
 
   class Wifi {
   public:
+    Wifi() : active(true) {
+    }
+
     bool active;
     class AP {
     public:
       String SSID;
       String password;
     };
-
-    Wifi() : active(true) {
-    }
 
     std::list<AP> APs;
   };
@@ -70,13 +70,13 @@ public:
     LoRa() : frequencyRx(433775000), frequencyTx(433775000), power(20), spreadingFactor(12), signalBandwidth(125000), codingRate4(5) {
     }
 
-    long frequencyRx;
+    long    frequencyRx;
     uint8_t gainRx;
-    long frequencyTx;
-    int  power;
-    int  spreadingFactor;
-    long signalBandwidth;
-    int  codingRate4;
+    long    frequencyTx;
+    int     power;
+    int     spreadingFactor;
+    long    signalBandwidth;
+    int     codingRate4;
   };
 
   class Display {

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -21,13 +21,14 @@ public:
 
   class Wifi {
   public:
+    bool active;
     class AP {
     public:
       String SSID;
       String password;
     };
 
-    Wifi() {
+    Wifi() : active(true) {
     }
 
     std::list<AP> APs;
@@ -70,6 +71,7 @@ public:
     }
 
     long frequencyRx;
+    uint8_t gainRx;
     long frequencyTx;
     int  power;
     int  spreadingFactor;


### PR DESCRIPTION
Added two options to is-cfg.json:
- enable WiFi on (PoE) Ethernet boards as proposed in issue, closing #116
- adjust LoRa receiver gain, closing #115 