### PR TITLE
feature request: lora.tx_only configuration option

### DIFF
--- a/src/TaskModem.cpp
+++ b/src/TaskModem.cpp
@@ -26,7 +26,7 @@ bool ModemTask::setup(System &system) {
   _lora_aprs.setRxFrequency(system.getUserConfig()->lora.frequencyRx);
   _lora_aprs.setRxGain(system.getUserConfig()->lora.gainRx);
   _lora_aprs.setTxFrequency(system.getUserConfig()->lora.frequencyTx);
-  _lora_aprs.setTxPower(system.getUserConfig()->lora.power);
+  _lora_aprs.setTxPower(system.getUserConfig()->lora.tx_enabled ? system.getUserConfig()->lora.power : 0);
   _lora_aprs.setSpreadingFactor(system.getUserConfig()->lora.spreadingFactor);
   _lora_aprs.setSignalBandwidth(system.getUserConfig()->lora.signalBandwidth);
   _lora_aprs.setCodingRate4(system.getUserConfig()->lora.codingRate4);
@@ -54,7 +54,8 @@ bool ModemTask::loop(System &system) {
 
   if (!_toModem.empty()) {
     std::shared_ptr<APRSMessage> msg = _toModem.getElement();
-    _lora_aprs.sendMessage(msg);
+    if (system.getUserConfig()->lora.tx_enabled)
+      _lora_aprs.sendMessage(msg);
   }
 
   return true;

--- a/src/TaskRouter.cpp
+++ b/src/TaskRouter.cpp
@@ -59,7 +59,7 @@ bool RouterTask::loop(System &system) {
         logPrintlnD("APRS-IS: no forward => own packet received");
     }
 
-    if (system.getUserConfig()->digi.active && modemMsg->getSource() != system.getUserConfig()->callsign) {
+    if (system.getUserConfig()->digi.active && system.getUserConfig()->lora.tx_enabled && modemMsg->getSource() != system.getUserConfig()->callsign) {
       std::shared_ptr<APRSMessage> digiMsg = std::make_shared<APRSMessage>(*modemMsg);
       String                       path    = digiMsg->getPath();
 
@@ -84,7 +84,7 @@ bool RouterTask::loop(System &system) {
     if (system.getUserConfig()->aprs_is.active)
       _toAprsIs.addElement(_beaconMsg);
 
-    if (system.getUserConfig()->digi.beacon) {
+    if (system.getUserConfig()->digi.beacon && system.getUserConfig()->lora.tx_enabled) {
       _toModem.addElement(_beaconMsg);
     }
 

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -58,10 +58,15 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
   conf.lora.spreadingFactor = data["lora"]["spreading_factor"] | 12;
   conf.lora.signalBandwidth = data["lora"]["signal_bandwidth"] | 125000;
   conf.lora.codingRate4     = data["lora"]["coding_rate4"] | 5;
+  conf.lora.tx_enabled      = data["lora"]["tx_enabled"] | false;
   conf.display.alwaysOn     = data["display"]["always_on"] | true;
   conf.display.timeout      = data["display"]["timeout"] | 10;
   conf.display.overwritePin = data["display"]["overwrite_pin"] | 0;
   conf.display.turn180      = data["display"]["turn180"] | true;
+  if (!conf.lora.tx_enabled) {
+    conf.digi.active = conf.digi.beacon = false;
+    conf.lora.power = 0;
+  }
 
   conf.ftp.active = data["ftp"]["active"] | false;
   JsonArray users = data["ftp"]["user"].as<JsonArray>();
@@ -113,15 +118,16 @@ void ProjectConfigurationManagement::writeProjectConfiguration(Configuration &co
   data["aprs_is"]["passcode"]             = conf.aprs_is.passcode;
   data["aprs_is"]["server"]               = conf.aprs_is.server;
   data["aprs_is"]["port"]                 = conf.aprs_is.port;
-  data["digi"]["active"]                  = conf.digi.active;
-  data["digi"]["beacon"]                  = conf.digi.beacon;
+  data["digi"]["active"]                  = conf.digi.active && conf.lora.tx_enabled;
+  data["digi"]["beacon"]                  = conf.digi.beacon && conf.lora.tx_enabled;
   data["lora"]["frequency_rx"]            = conf.lora.frequencyRx;
   data["lora"]["gain_rx"]                 = conf.lora.gainRx;
   data["lora"]["frequency_tx"]            = conf.lora.frequencyTx;
-  data["lora"]["power"]                   = conf.lora.power;
+  data["lora"]["power"]                   = conf.lora.tx_enabled ? conf.lora.power : 0;
   data["lora"]["spreading_factor"]        = conf.lora.spreadingFactor;
   data["lora"]["signal_bandwidth"]        = conf.lora.signalBandwidth;
   data["lora"]["coding_rate4"]            = conf.lora.codingRate4;
+  data["lora"]["tx_enabled"]              = conf.lora.tx_enabled;
   data["display"]["always_on"]            = conf.display.alwaysOn;
   data["display"]["timeout"]              = conf.display.timeout;
   data["display"]["overwrite_pin"]        = conf.display.overwritePin;

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -79,7 +79,7 @@ public:
 
   class LoRa {
   public:
-    LoRa() : frequencyRx(433775000), frequencyTx(433775000), power(20), spreadingFactor(12), signalBandwidth(125000), codingRate4(5) {
+    LoRa() : frequencyRx(433775000), frequencyTx(433775000), power(20), spreadingFactor(12), signalBandwidth(125000), codingRate4(5), tx_enabled(false) {
     }
 
     long    frequencyRx;
@@ -89,6 +89,7 @@ public:
     int     spreadingFactor;
     long    signalBandwidth;
     int     codingRate4;
+    bool    tx_enabled;
   };
 
   class Display {


### PR DESCRIPTION
 This commit suggests a new config option in the lora section: tx_only (-> assurance, that TX never happens)

At most locations, we operate in listen-only mode.

 -> digi.active = false
     digi.beacon = false

Sometimes, we are behind an rx rf-amplifier, or use the rx-antenna together with
an other rx.
Then it's very important inhibit unexpected or TX, i.e. after config loss. Else it
would seriously damage our hardware.
If there are bugs, or if new features will come in (i.E. initial beacon on boot up),
I suppose a variable
  tx_enabled in the 'lora' section.
which defaults to false.

This variable assures that digi.active and digi.beacon is set to false, txpower is
set to 0dBm, and that the tx-routine is never entered.

=> The new configuration variable in is-cfg.json in the
   "lora": {
   }
   section is
     tx_enabled = false

I.e.:
        ..
        "lora": {
                "frequency_rx": 433775000,
                "gain_rx": 0,
                "frequency_tx": 433775000,
                "power": 20,
                "spreading_factor": 12,
                "signal_bandwidth": 125000,
                "coding_rate4": 5,
                "tx_enabled" = false
        },
        ..

Set tx_enabled to true if you are sure you safely can tx on 70cm lora.

Signed-off-by: Thomas Osterried <dl9sau@darc.de>