### PR TITLE
Add is-cfg.json to lora.txok for SWL station.

### DIFF
--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -48,7 +48,8 @@
 		"power": 20,
 		"spreading_factor": 12,
 		"signal_bandwidth": 125000,
-		"coding_rate4": 5
+		"coding_rate4": 5,
+		"txok": true
 	},
 	"display": {
 		"always_on": true,

--- a/src/TaskModem.cpp
+++ b/src/TaskModem.cpp
@@ -54,7 +54,14 @@ bool ModemTask::loop(System &system) {
 
   if (!_toModem.empty()) {
     std::shared_ptr<APRSMessage> msg = _toModem.getElement();
-    _lora_aprs.sendMessage(msg);
+    logPrintlnD(msg->toString());
+    if (system.getUserConfig()->lora.txok) {
+      logPrintD(String("-- TXOK"));
+      _lora_aprs.sendMessage(msg);
+      logPrintlnD(String(" -- TXDone"));
+    } else {
+      logPrintlnD(String("-- TXNG"));
+    }
   }
 
   return true;

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -58,6 +58,7 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
   conf.lora.spreadingFactor = data["lora"]["spreading_factor"] | 12;
   conf.lora.signalBandwidth = data["lora"]["signal_bandwidth"] | 125000;
   conf.lora.codingRate4     = data["lora"]["coding_rate4"] | 5;
+  conf.lora.txok            = data["lora"]["txok"] | false;
   conf.display.alwaysOn     = data["display"]["always_on"] | true;
   conf.display.timeout      = data["display"]["timeout"] | 10;
   conf.display.overwritePin = data["display"]["overwrite_pin"] | 0;

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -89,6 +89,7 @@ public:
     int     spreadingFactor;
     long    signalBandwidth;
     int     codingRate4;
+    bool    txok;
   };
 
   class Display {


### PR DESCRIPTION
This PR adds is-cfg.json to lora.txok flag.
This is for SWL stations or the stations who prepares to get a (no comprehensive) radio license.