### PR TITLE
Add GPS function for setting beacon position.

### DIFF
--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -29,6 +29,7 @@
 			"latitude": 0.000000,
 			"longitude": 0.000000
 		},
+		"gps": true,
 		"timeout": 15
 	},
 	"aprs_is": {

--- a/lib/BoardFinder/BoardFinder.cpp
+++ b/lib/BoardFinder/BoardFinder.cpp
@@ -2,8 +2,8 @@
 #include <logger.h>
 #include <power_management.h>
 
-BoardConfig::BoardConfig(String name, BoardType type, uint8_t oledsda, uint8_t oledscl, uint8_t oledaddr, uint8_t oledreset, uint8_t lorasck, uint8_t loramiso, uint8_t loramosi, uint8_t loracs, uint8_t lorareset, uint8_t lorairq, bool needcheckpowerchip, bool powercheckstatus)
-    : Name(name), Type(type), OledSda(oledsda), OledScl(oledscl), OledAddr(oledaddr), OledReset(oledreset), LoraSck(lorasck), LoraMiso(loramiso), LoraMosi(loramosi), LoraCS(loracs), LoraReset(lorareset), LoraIRQ(lorairq), needCheckPowerChip(needcheckpowerchip), powerCheckStatus(powercheckstatus) {
+BoardConfig::BoardConfig(String name, BoardType type, uint8_t oledsda, uint8_t oledscl, uint8_t oledaddr, uint8_t oledreset, uint8_t lorasck, uint8_t loramiso, uint8_t loramosi, uint8_t loracs, uint8_t lorareset, uint8_t lorairq, uint8_t gpsrx, uint8_t gpstx, bool needcheckpowerchip, bool powercheckstatus)
+    : Name(name), Type(type), OledSda(oledsda), OledScl(oledscl), OledAddr(oledaddr), OledReset(oledreset), LoraSck(lorasck), LoraMiso(loramiso), LoraMosi(loramosi), LoraCS(loracs), LoraReset(lorareset), LoraIRQ(lorairq), GpsRx(gpsrx), GpsTx(gpstx), needCheckPowerChip(needcheckpowerchip), powerCheckStatus(powercheckstatus) {
 }
 
 BoardFinder::BoardFinder(const std::list<BoardConfig const *> &boardConfigs) : _boardConfigs(boardConfigs) {
@@ -130,12 +130,12 @@ bool BoardFinder::checkPowerConfig(BoardConfig const *boardConfig) {
 }
 
 // clang-format off
-BoardConfig TTGO_LORA32_V1        ("TTGO_LORA32_V1",         eTTGO_LORA32_V1,          4, 15, 0x3C,  0,  5, 19, 27, 18, 14, 26);
-BoardConfig TTGO_LORA32_V2        ("TTGO_LORA32_V2",         eTTGO_LORA32_V2,         21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, true);
-BoardConfig TTGO_T_Beam_V0_7      ("TTGO_T_Beam_V0_7",       eTTGO_T_Beam_V0_7,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, true);
-BoardConfig TTGO_T_Beam_V1_0      ("TTGO_T_Beam_V1_0",       eTTGO_T_Beam_V1_0,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, true, true);
-BoardConfig ETH_BOARD             ("ETH_BOARD",              eETH_BOARD,              33, 32, 0x3C,  0, 14,  2, 15, 12,  4, 36);
-BoardConfig TRACKERD              ("TRACKERD",               eTRACKERD,                5,  4, 0x3C,  0, 18, 19, 23, 16, 14, 26);
-BoardConfig HELTEC_WIFI_LORA_32_V1("HELTEC_WIFI_LORA_32_V1", eHELTEC_WIFI_LORA_32_V1,  4, 15, 0x3C, 16,  5, 19, 27, 18, 14, 26);
-BoardConfig HELTEC_WIFI_LORA_32_V2("HELTEC_WIFI_LORA_32_V2", eHELTEC_WIFI_LORA_32_V2,  4, 15, 0x3C, 16,  5, 19, 27, 18, 14, 26);
+BoardConfig TTGO_LORA32_V1        ("TTGO_LORA32_V1",         eTTGO_LORA32_V1,          4, 15, 0x3C,  0,  5, 19, 27, 18, 14, 26,  0,  0);
+BoardConfig TTGO_LORA32_V2        ("TTGO_LORA32_V2",         eTTGO_LORA32_V2,         21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26,  0,  0, true);
+BoardConfig TTGO_T_Beam_V0_7      ("TTGO_T_Beam_V0_7",       eTTGO_T_Beam_V0_7,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, 15, 12, true);
+BoardConfig TTGO_T_Beam_V1_0      ("TTGO_T_Beam_V1_0",       eTTGO_T_Beam_V1_0,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, 12, 34, true, true);
+BoardConfig ETH_BOARD             ("ETH_BOARD",              eETH_BOARD,              33, 32, 0x3C,  0, 14,  2, 15, 12,  4, 36,  0,  0);
+BoardConfig TRACKERD              ("TRACKERD",               eTRACKERD,                5,  4, 0x3C,  0, 18, 19, 23, 16, 14, 26,  0,  0);
+BoardConfig HELTEC_WIFI_LORA_32_V1("HELTEC_WIFI_LORA_32_V1", eHELTEC_WIFI_LORA_32_V1,  4, 15, 0x3C, 16,  5, 19, 27, 18, 14, 26,  0,  0);
+BoardConfig HELTEC_WIFI_LORA_32_V2("HELTEC_WIFI_LORA_32_V2", eHELTEC_WIFI_LORA_32_V2,  4, 15, 0x3C, 16,  5, 19, 27, 18, 14, 26,  0,  0);
 // clang-format on

--- a/lib/BoardFinder/BoardFinder.h
+++ b/lib/BoardFinder/BoardFinder.h
@@ -22,7 +22,7 @@ enum BoardType
 
 class BoardConfig {
 public:
-  explicit BoardConfig(String name, BoardType type, uint8_t oledsda, uint8_t oledscl, uint8_t oledaddr, uint8_t oledreset, uint8_t lorasck, uint8_t loramiso, uint8_t loramosi, uint8_t loracs, uint8_t lorareset, uint8_t lorairq, bool needcheckpowerchip = false, bool powercheckstatus = false);
+  explicit BoardConfig(String name, BoardType type, uint8_t oledsda, uint8_t oledscl, uint8_t oledaddr, uint8_t oledreset, uint8_t lorasck, uint8_t loramiso, uint8_t loramosi, uint8_t loracs, uint8_t lorareset, uint8_t lorairq, uint8_t gpsrx, uint8_t gpstx, bool needcheckpowerchip = false, bool powercheckstatus = false);
 
   String    Name;
   BoardType Type;
@@ -38,6 +38,8 @@ public:
   uint8_t LoraCS;
   uint8_t LoraReset;
   uint8_t LoraIRQ;
+  uint8_t GpsRx;
+  uint8_t GpsTx;
 
   bool needCheckPowerChip;
   bool powerCheckStatus;

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ lib_deps =
 	peterus/esp-logger @ 1.0.0
 	peterus/ESP-FTP-Server-Lib @ 0.9.5
 	knolleary/PubSubClient@^2.8
+	mikalhart/TinyGPSPlus @ 1.0.2
 check_tool = cppcheck
 check_flags =
 	cppcheck: --suppress=*:*.pio\* --inline-suppr -DCPPCHECK --force lib -ilib/TimeLib -ilib/LoRa -ilib/NTPClient

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -8,6 +8,7 @@
 #include <power_management.h>
 
 #include "TaskAprsIs.h"
+#include "TaskBeacon.h"
 #include "TaskDisplay.h"
 #include "TaskEth.h"
 #include "TaskFTP.h"
@@ -42,6 +43,7 @@ FTPTask     ftpTask;
 MQTTTask    mqttTask(toMQTT);
 AprsIsTask  aprsIsTask(toAprsIs);
 RouterTask  routerTask(fromModem, toModem, toAprsIs, toMQTT);
+BeaconTask  beaconTask(toModem, toAprsIs);
 
 void setup() {
   Serial.begin(115200);
@@ -93,7 +95,11 @@ void setup() {
     }
     powerManagement.activateLoRa();
     powerManagement.activateOLED();
-    powerManagement.deactivateGPS();
+    if (userConfig.beacon.gps) {
+      powerManagement.activateGPS();
+    } else {
+      powerManagement.deactivateGPS();
+    }
   }
 
   LoRaSystem.setBoardConfig(boardConfig);
@@ -101,6 +107,7 @@ void setup() {
   LoRaSystem.getTaskManager().addTask(&displayTask);
   LoRaSystem.getTaskManager().addTask(&modemTask);
   LoRaSystem.getTaskManager().addTask(&routerTask);
+  LoRaSystem.getTaskManager().addTask(&beaconTask);
 
   if (userConfig.aprs_is.active) {
     if (boardConfig->Type == eETH_BOARD && !userConfig.wifi.active) {
@@ -149,28 +156,4 @@ void setup() {
 
 void loop() {
   LoRaSystem.getTaskManager().loop(LoRaSystem);
-}
-
-String create_lat_aprs(double lat) {
-  char str[20];
-  char n_s = 'N';
-  if (lat < 0) {
-    n_s = 'S';
-  }
-  lat = std::abs(lat);
-  sprintf(str, "%02d%05.2f%c", (int)lat, (lat - (double)((int)lat)) * 60.0, n_s);
-  String lat_str(str);
-  return lat_str;
-}
-
-String create_long_aprs(double lng) {
-  char str[20];
-  char e_w = 'E';
-  if (lng < 0) {
-    e_w = 'W';
-  }
-  lng = std::abs(lng);
-  sprintf(str, "%03d%05.2f%c", (int)lng, (lng - (double)((int)lng)) * 60.0, e_w);
-  String lng_str(str);
-  return lng_str;
 }

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -20,7 +20,7 @@
 #include "TaskWifi.h"
 #include "project_configuration.h"
 
-#define VERSION     "22.11.2"
+#define VERSION     "22.12.0"
 #define MODULE_NAME "Main"
 
 String create_lat_aprs(double lat);

--- a/src/Task.h
+++ b/src/Task.h
@@ -12,6 +12,7 @@ enum TaskNames
   TaskWifi,
   TaskRouter,
   TaskMQTT,
+  TaskBeacon,
   TaskSize
 };
 
@@ -24,5 +25,6 @@ enum TaskNames
 #define TASK_WIFI    "WifiTask"
 #define TASK_ROUTER  "RouterTask"
 #define TASK_MQTT    "MQTTTask"
+#define TASK_BEACON  "BeaconTask"
 
 #endif

--- a/src/TaskBeacon.cpp
+++ b/src/TaskBeacon.cpp
@@ -44,8 +44,7 @@ bool BeaconTask::loop(System &system) {
   }
 
   // check for beacon
-  if (_beacon_timer.check()) {
-    if setBeacon (system) {
+    if (setBeacon(system)) {
       _beacon_timer.start();
     }
   }

--- a/src/TaskBeacon.cpp
+++ b/src/TaskBeacon.cpp
@@ -20,7 +20,7 @@ bool BeaconTask::setup(System &system) {
     if (system.getBoardConfig()->GpsRx != 0) {
       ss.begin(9600, SERIAL_8N1, system.getBoardConfig()->GpsTx, system.getBoardConfig()->GpsRx);
     } else {
-      logPrintlnD("NO GPS found.");
+      system.getLogger().log(logging::LoggerLevel::LOGGER_LEVEL_INFO, getName(), "NO GPS found.");
       gpsok = false;
     }
   }
@@ -44,12 +44,11 @@ bool BeaconTask::loop(System &system) {
   }
 
   setBeacon(system);
-}
 
-uint32_t diff = _beacon_timer.getTriggerTimeInSec();
-_stateInfo    = "beacon " + String(uint32_t(diff / 600)) + String(uint32_t(diff / 60) % 10) + ":" + String(uint32_t(diff / 10) % 6) + String(uint32_t(diff % 10));
+  uint32_t diff = _beacon_timer.getTriggerTimeInSec();
+  _stateInfo    = "beacon " + String(uint32_t(diff / 600)) + String(uint32_t(diff / 60) % 10) + ":" + String(uint32_t(diff / 10) % 6) + String(uint32_t(diff % 10));
 
-return true;
+  return true;
 }
 
 String create_lat_aprs(double lat) {
@@ -96,8 +95,7 @@ void BeaconTask::setBeacon(System &system) {
     }
     _beaconMsg->getBody()->setData(String("=") + create_lat_aprs(lat) + "L" + create_long_aprs(lng) + "&" + system.getUserConfig()->beacon.message);
 
-    logPrintD("[" + timeString() + "] ");
-    logPrintlnD(_beaconMsg->encode());
+    system.getLogger().log(logging::LoggerLevel::LOGGER_LEVEL_INFO, getName(), "[%s]%s", timeString(), _beaconMsg->encode());
 
     if (system.getUserConfig()->aprs_is.active)
       _toAprsIs.addElement(_beaconMsg);

--- a/src/TaskBeacon.cpp
+++ b/src/TaskBeacon.cpp
@@ -95,7 +95,7 @@ void BeaconTask::setBeacon(System &system) {
     }
     _beaconMsg->getBody()->setData(String("=") + create_lat_aprs(lat) + "L" + create_long_aprs(lng) + "&" + system.getUserConfig()->beacon.message);
 
-    system.getLogger().log(logging::LoggerLevel::LOGGER_LEVEL_INFO, getName(), "[%s]%s", timeString(), _beaconMsg->encode());
+    system.getLogger().log(logging::LoggerLevel::LOGGER_LEVEL_INFO, getName(), "[%s]%s", timeString().c_str(), _beaconMsg->encode().c_str());
 
     if (system.getUserConfig()->aprs_is.active)
       _toAprsIs.addElement(_beaconMsg);

--- a/src/TaskBeacon.cpp
+++ b/src/TaskBeacon.cpp
@@ -44,6 +44,7 @@ bool BeaconTask::loop(System &system) {
   }
 
   // check for beacon
+  if (_beacon_timer.check()) {
     if (setBeacon(system)) {
       _beacon_timer.start();
     }

--- a/src/TaskBeacon.cpp
+++ b/src/TaskBeacon.cpp
@@ -1,0 +1,113 @@
+#include <logger.h>
+
+#include <TimeLib.h>
+
+#include "Task.h"
+#include "TaskBeacon.h"
+#include "project_configuration.h"
+
+BeaconTask::BeaconTask(TaskQueue<std::shared_ptr<APRSMessage>> &toModem, TaskQueue<std::shared_ptr<APRSMessage>> &toAprsIs) : Task(TASK_BEACON, TaskBeacon), _toModem(toModem), _toAprsIs(toAprsIs), ss(1), gpsok(false) {
+}
+
+BeaconTask::~BeaconTask() {
+}
+
+bool BeaconTask::setup(System &system) {
+  gpsok = system.getUserConfig()->beacon.gps;
+
+  // Setup GPS
+  if (gpsok) {
+    if (system.getBoardConfig()->GpsRx != 0) {
+      ss.begin(9600, SERIAL_8N1, system.getBoardConfig()->GpsTx, system.getBoardConfig()->GpsRx);
+    } else {
+      logPrintlnD("NO GPS found.");
+      gpsok = false;
+    }
+  }
+  // setup beacon
+  _beacon_timer.setTimeout(system.getUserConfig()->beacon.timeout * 60 * 1000);
+
+  _beaconMsg = std::shared_ptr<APRSMessage>(new APRSMessage());
+  _beaconMsg->setSource(system.getUserConfig()->callsign);
+  _beaconMsg->setDestination("APLG01");
+
+  return true;
+}
+
+bool BeaconTask::loop(System &system) {
+
+  if (gpsok) {
+    while (ss.available() > 0) {
+      char c = ss.read();
+      gps.encode(c);
+    }
+  }
+
+  setBeacon(system);
+}
+
+uint32_t diff = _beacon_timer.getTriggerTimeInSec();
+_stateInfo    = "beacon " + String(uint32_t(diff / 600)) + String(uint32_t(diff / 60) % 10) + ":" + String(uint32_t(diff / 10) % 6) + String(uint32_t(diff % 10));
+
+return true;
+}
+
+String create_lat_aprs(double lat) {
+  char str[20];
+  char n_s = 'N';
+  if (lat < 0) {
+    n_s = 'S';
+  }
+  lat = std::abs(lat);
+  sprintf(str, "%02d%05.2f%c", (int)lat, (lat - (double)((int)lat)) * 60.0, n_s);
+  String lat_str(str);
+  return lat_str;
+}
+
+String create_long_aprs(double lng) {
+  char str[20];
+  char e_w = 'E';
+  if (lng < 0) {
+    e_w = 'W';
+  }
+  lng = std::abs(lng);
+  sprintf(str, "%03d%05.2f%c", (int)lng, (lng - (double)((int)lng)) * 60.0, e_w);
+  String lng_str(str);
+  return lng_str;
+}
+
+void BeaconTask::setBeacon(System &system) {
+  // check for beacon
+  if (_beacon_timer.check()) {
+    double lat, lng;
+
+    if (gpsok) {
+      // bool gps_time_update = gps.time.isUpdated();
+      bool gps_loc_update = gps.location.isUpdated();
+
+      if (!gps_loc_update) {
+        return;
+      }
+      lat = gps.location.lat();
+      lng = gps.location.lng();
+    } else {
+      lat = system.getUserConfig()->beacon.positionLatitude;
+      lng = system.getUserConfig()->beacon.positionLongitude;
+    }
+    _beaconMsg->getBody()->setData(String("=") + create_lat_aprs(lat) + "L" + create_long_aprs(lng) + "&" + system.getUserConfig()->beacon.message);
+
+    logPrintD("[" + timeString() + "] ");
+    logPrintlnD(_beaconMsg->encode());
+
+    if (system.getUserConfig()->aprs_is.active)
+      _toAprsIs.addElement(_beaconMsg);
+
+    if (system.getUserConfig()->digi.beacon) {
+      _toModem.addElement(_beaconMsg);
+    }
+
+    system.getDisplay().addFrame(std::shared_ptr<DisplayFrame>(new TextFrame("BEACON", _beaconMsg->toString())));
+
+    _beacon_timer.start();
+  }
+}

--- a/src/TaskBeacon.h
+++ b/src/TaskBeacon.h
@@ -14,7 +14,7 @@ public:
 
   virtual bool setup(System &system) override;
   virtual bool loop(System &system) override;
-  void         setBeacon(System &system);
+  bool         setBeacon(System &system);
 
 private:
   TaskQueue<std::shared_ptr<APRSMessage>> &_toModem;

--- a/src/TaskBeacon.h
+++ b/src/TaskBeacon.h
@@ -1,0 +1,31 @@
+#ifndef TASK_BEACON_H_
+#define TASK_BEACON_H_
+
+#include <TinyGPS++.h>
+
+#include <APRSMessage.h>
+#include <TaskMQTT.h>
+#include <TaskManager.h>
+
+class BeaconTask : public Task {
+public:
+  BeaconTask(TaskQueue<std::shared_ptr<APRSMessage>> &toModem, TaskQueue<std::shared_ptr<APRSMessage>> &toAprsIs);
+  virtual ~BeaconTask();
+
+  virtual bool setup(System &system) override;
+  virtual bool loop(System &system) override;
+  void         setBeacon(System &system);
+
+private:
+  TaskQueue<std::shared_ptr<APRSMessage>> &_toModem;
+  TaskQueue<std::shared_ptr<APRSMessage>> &_toAprsIs;
+
+  std::shared_ptr<APRSMessage> _beaconMsg;
+  Timer                        _beacon_timer;
+
+  HardwareSerial ss;
+  TinyGPSPlus    gps;
+  bool           gpsok;
+};
+
+#endif

--- a/src/TaskRouter.cpp
+++ b/src/TaskRouter.cpp
@@ -6,9 +6,6 @@
 #include "TaskRouter.h"
 #include "project_configuration.h"
 
-String create_lat_aprs(double lat);
-String create_long_aprs(double lng);
-
 RouterTask::RouterTask(TaskQueue<std::shared_ptr<APRSMessage>> &fromModem, TaskQueue<std::shared_ptr<APRSMessage>> &toModem, TaskQueue<std::shared_ptr<APRSMessage>> &toAprsIs, TaskQueue<std::shared_ptr<APRSMessage>> &toMQTT) : Task(TASK_ROUTER, TaskRouter), _fromModem(fromModem), _toModem(toModem), _toAprsIs(toAprsIs), _toMQTT(toMQTT) {
 }
 
@@ -16,16 +13,6 @@ RouterTask::~RouterTask() {
 }
 
 bool RouterTask::setup(System &system) {
-  // setup beacon
-  _beacon_timer.setTimeout(system.getUserConfig()->beacon.timeout * 60 * 1000);
-
-  _beaconMsg = std::shared_ptr<APRSMessage>(new APRSMessage());
-  _beaconMsg->setSource(system.getUserConfig()->callsign);
-  _beaconMsg->setDestination("APLG01");
-  String lat = create_lat_aprs(system.getUserConfig()->beacon.positionLatitude);
-  String lng = create_long_aprs(system.getUserConfig()->beacon.positionLongitude);
-  _beaconMsg->getBody()->setData(String("=") + lat + "L" + lng + "&" + system.getUserConfig()->beacon.message);
-
   return true;
 }
 
@@ -80,25 +67,7 @@ bool RouterTask::loop(System &system) {
     }
   }
 
-  // check for beacon
-  if (_beacon_timer.check()) {
-    logPrintD("[" + timeString() + "] ");
-    logPrintlnD(_beaconMsg->encode());
-
-    if (system.getUserConfig()->aprs_is.active)
-      _toAprsIs.addElement(_beaconMsg);
-
-    if (system.getUserConfig()->digi.beacon) {
-      _toModem.addElement(_beaconMsg);
-    }
-
-    system.getDisplay().addFrame(std::shared_ptr<DisplayFrame>(new TextFrame("BEACON", _beaconMsg->toString())));
-
-    _beacon_timer.start();
-  }
-
-  uint32_t diff = _beacon_timer.getTriggerTimeInSec();
-  _stateInfo    = "beacon " + String(uint32_t(diff / 600)) + String(uint32_t(diff / 60) % 10) + ":" + String(uint32_t(diff / 10) % 6) + String(uint32_t(diff % 10));
+  _stateInfo = "Router done ";
 
   return true;
 }

--- a/src/TaskRouter.h
+++ b/src/TaskRouter.h
@@ -18,9 +18,6 @@ private:
   TaskQueue<std::shared_ptr<APRSMessage>> &_toModem;
   TaskQueue<std::shared_ptr<APRSMessage>> &_toAprsIs;
   TaskQueue<std::shared_ptr<APRSMessage>> &_toMQTT;
-
-  std::shared_ptr<APRSMessage> _beaconMsg;
-  Timer                        _beacon_timer;
 };
 
 #endif

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -41,6 +41,7 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
     conf.beacon.message = data["beacon"]["message"].as<String>();
   conf.beacon.positionLatitude  = data["beacon"]["position"]["latitude"] | 0.0;
   conf.beacon.positionLongitude = data["beacon"]["position"]["longitude"] | 0.0;
+  conf.beacon.gps               = data["beacon"]["gps"] | false;
   conf.beacon.timeout           = data["beacon"]["timeout"] | 15;
   conf.aprs_is.active           = data["aprs_is"]["active"] | true;
   if (data.containsKey("aprs_is") && data["aprs_is"].containsKey("passcode"))
@@ -117,6 +118,7 @@ void ProjectConfigurationManagement::writeProjectConfiguration(Configuration &co
   data["beacon"]["message"]               = conf.beacon.message;
   data["beacon"]["position"]["latitude"]  = conf.beacon.positionLatitude;
   data["beacon"]["position"]["longitude"] = conf.beacon.positionLongitude;
+  data["beacon"]["gps"]                   = conf.beacon.gps;
   data["beacon"]["timeout"]               = conf.beacon.timeout;
   data["aprs_is"]["active"]               = conf.aprs_is.active;
   data["aprs_is"]["passcode"]             = conf.aprs_is.passcode;

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -48,12 +48,13 @@ public:
 
   class Beacon {
   public:
-    Beacon() : message("LoRa iGATE & Digi, Info: github.com/peterus/LoRa_APRS_iGate"), positionLatitude(0.0), positionLongitude(0.0), timeout(15) {
+    Beacon() : message("LoRa iGATE & Digi, Info: github.com/peterus/LoRa_APRS_iGate"), positionLatitude(0.0), positionLongitude(0.0), gps(false), timeout(15) {
     }
 
     String message;
     double positionLatitude;
     double positionLongitude;
+    bool   gps;
     int    timeout;
   };
 


### PR DESCRIPTION
This PR adds the function to use GPS instead of setting beacon.position as beacon's local position.
In this version, smart beaconing is not supported.
So, this is not suitable for mobile stations.

I've tested on only T-Beam V1.0 because of the environment limitation.