### PR TITLE
last octet of ip address and signal stength for WiFi

### DIFF
--- a/src/TaskWifi.cpp
+++ b/src/TaskWifi.cpp
@@ -52,7 +52,7 @@ bool WifiTask::loop(System &system) {
     return false;
   }
   system.connectedViaWifi(true);
-  _stateInfo = WiFi.localIP().toString();
+  _stateInfo = String("IP .") + String(WiFi.localIP()[3]) + String(" @ ") + String(WiFi.RSSI()) + String("dBm");
   _state     = Okay;
   return true;
 }


### PR DESCRIPTION
show the signal strength of the wifi signal on display (status page).
to fit the line only the last octet of ip address is shown and appended the dBm value.
helps to place the iGate optimal for good WiFi signal
and the first 3 octets of the ip address should be known to everyone