### PR TITLE
remove syslog server

### DIFF
--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -77,7 +77,7 @@
 	},
 	"syslog": {
 		"active": false,
-		"server": "syslog.lora-aprs.info",
+		"server": "",
 		"port": 514
 	},
 	"ntp_server": "pool.ntp.org"

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -134,7 +134,7 @@ public:
 
   class Syslog {
   public:
-    Syslog() : active(true), server("syslog.lora-aprs.info"), port(514) {
+    Syslog() : active(true), server(""), port(514) {
     }
 
     bool   active;


### PR DESCRIPTION
public syslog server is dead and can not be used anymore. lets remove it from the config.