### PR TITLE
Fix board config

### DIFF
--- a/lib/BoardFinder/BoardFinder.cpp
+++ b/lib/BoardFinder/BoardFinder.cpp
@@ -131,7 +131,7 @@ bool BoardFinder::checkPowerConfig(BoardConfig const *boardConfig, logging::Logg
 
 // clang-format off
 BoardConfig TTGO_LORA32_V1        ("TTGO_LORA32_V1",         eTTGO_LORA32_V1,          4, 15, 0x3C,  0,  5, 19, 27, 18, 14, 26,  0,  0,  0);
-BoardConfig TTGO_LORA32_V2        ("TTGO_LORA32_V2",         eTTGO_LORA32_V2,         21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26,  0,  0,  0, true);
+BoardConfig TTGO_LORA32_V2        ("TTGO_LORA32_V2",         eTTGO_LORA32_V2,         21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26,  0,  0,  0);
 BoardConfig TTGO_T_Beam_V0_7      ("TTGO_T_Beam_V0_7",       eTTGO_T_Beam_V0_7,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, 15, 12, 38, true);
 BoardConfig TTGO_T_Beam_V1_0      ("TTGO_T_Beam_V1_0",       eTTGO_T_Beam_V1_0,       21, 22, 0x3C,  0,  5, 19, 27, 18, 14, 26, 12, 34, 38, true, true);
 BoardConfig ETH_BOARD             ("ETH_BOARD",              eETH_BOARD,              33, 32, 0x3C,  0, 14,  2, 15, 12,  4, 36,  0,  0,  0);

--- a/lib/BoardFinder/BoardFinder.cpp
+++ b/lib/BoardFinder/BoardFinder.cpp
@@ -21,7 +21,6 @@ BoardConfig const *BoardFinder::searchBoardConfig(logging::Logger &logger) {
       Wire.begin(boardconf->OledSda, boardconf->OledScl);
       powerManagement.begin(Wire);
       powerManagement.activateOLED();
-      Wire.end();
     } else if (boardconf->needCheckPowerChip) {
       continue;
     }
@@ -39,7 +38,6 @@ BoardConfig const *BoardFinder::searchBoardConfig(logging::Logger &logger) {
       Wire.begin(boardconf->OledSda, boardconf->OledScl);
       powerManagement.begin(Wire);
       powerManagement.activateLoRa();
-      Wire.end();
     }
     if (checkModemConfig(boardconf)) {
       logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, MODULE_NAME, "found a board config: %s", boardconf->Name.c_str());
@@ -77,10 +75,8 @@ bool BoardFinder::checkOledConfig(BoardConfig const *boardConfig, logging::Logge
   }
   Wire.beginTransmission(boardConfig->OledAddr);
   if (!Wire.endTransmission()) {
-    Wire.end();
     return true;
   }
-  Wire.end();
   return false;
 }
 
@@ -102,8 +98,9 @@ bool BoardFinder::checkModemConfig(BoardConfig const *boardConfig) {
   SPI.transfer(0x42);
   uint8_t response = SPI.transfer(0x00);
   SPI.endTransaction();
+
   digitalWrite(boardConfig->LoraCS, HIGH);
-  SPI.end();
+
   if (response == 0x12) {
     return true;
   }
@@ -122,8 +119,6 @@ bool BoardFinder::checkPowerConfig(BoardConfig const *boardConfig, logging::Logg
   Wire.requestFrom(0x34, 1);
   int response = Wire.read();
   Wire.endTransmission();
-
-  Wire.end();
 
   logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, MODULE_NAME, "wire response: %d", response);
   if (response == 0x03) {

--- a/lib/BoardFinder/BoardFinder.cpp
+++ b/lib/BoardFinder/BoardFinder.cpp
@@ -21,6 +21,7 @@ BoardConfig const *BoardFinder::searchBoardConfig(logging::Logger &logger) {
       Wire.begin(boardconf->OledSda, boardconf->OledScl);
       powerManagement.begin(Wire);
       powerManagement.activateOLED();
+      Wire.end();
     } else if (boardconf->needCheckPowerChip) {
       continue;
     }
@@ -38,6 +39,7 @@ BoardConfig const *BoardFinder::searchBoardConfig(logging::Logger &logger) {
       Wire.begin(boardconf->OledSda, boardconf->OledScl);
       powerManagement.begin(Wire);
       powerManagement.activateLoRa();
+      Wire.end();
     }
     if (checkModemConfig(boardconf)) {
       logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, MODULE_NAME, "found a board config: %s", boardconf->Name.c_str());
@@ -75,8 +77,10 @@ bool BoardFinder::checkOledConfig(BoardConfig const *boardConfig, logging::Logge
   }
   Wire.beginTransmission(boardConfig->OledAddr);
   if (!Wire.endTransmission()) {
+    Wire.end();
     return true;
   }
+  Wire.end();
   return false;
 }
 
@@ -98,9 +102,8 @@ bool BoardFinder::checkModemConfig(BoardConfig const *boardConfig) {
   SPI.transfer(0x42);
   uint8_t response = SPI.transfer(0x00);
   SPI.endTransaction();
-
   digitalWrite(boardConfig->LoraCS, HIGH);
-
+  SPI.end();
   if (response == 0x12) {
     return true;
   }
@@ -119,6 +122,8 @@ bool BoardFinder::checkPowerConfig(BoardConfig const *boardConfig, logging::Logg
   Wire.requestFrom(0x34, 1);
   int response = Wire.read();
   Wire.endTransmission();
+
+  Wire.end();
 
   logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, MODULE_NAME, "wire response: %d", response);
   if (response == 0x03) {


### PR DESCRIPTION
I tried updating the dependencies. I discovered that the boardconfig functions to find the current board have bugs.

1. The LoRa32 V2 board does not have a power management chip
2. If you do not call Wire.end() (or SPI.end() ) after trying a board, the next calls to Wire.begin() (or SPI.begin() ) might not update the selected pins and thus, the function will not be able to properly regognise boards.