### PR TITLE
Fix power limitations on 20dBm TX iGate

### DIFF
--- a/src/TaskRadiolib.cpp
+++ b/src/TaskRadiolib.cpp
@@ -100,6 +100,10 @@ bool RadiolibTask::setup(System &system) {
     }
   }
 
+  if (config.power > 17 && config.tx_enable) {
+    radio->setCurrentLimit(140);
+  }
+
   preambleDurationMilliSec = ((uint64_t)(preambleLength + 4) << (config.spreadingFactor + 10 /* to milli-sec */)) / config.signalBandwidth;
 
   _stateInfo = "";


### PR DESCRIPTION
Hello, RadioLib default setting is to set the current limiter to 60 mA on SX127x as per [Default-configuration](https://github.com/jgromes/RadioLib/wiki/Default-configuration). This means that when using PA pin the TX power is limited by the current (which does not happen in the LoRa_APRS_Tracker as it uses different library).

For TX-enabled iGate OCP (over-current-protection), I have added a simple fix based on the code in the tracker LoRa library which should enable full TX power (unless keeping the limit is intentional to prevent overloading the iGate if there is too much traffic and the 1% duty cycle and SWR < 1:3 as per SX127x documentation Table 35 is not observed). Theoretically an adjustment for 15-17 dBm may also have to be applied.