### PR TITLE
Implement MQTT "last will" and "birth message"

### DIFF
--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -73,7 +73,11 @@
 		"port": 1883,
 		"name": "",
 		"password": "",
-		"topic": "LoraAPRS/Data"
+		"topic": "LoraAPRS/Data",
+		"will_active": false,
+        "will_topic": "LoraAPRS/State",
+        "will_message": "offline",
+        "birth_message": "online"
 	},
 	"syslog": {
 		"active": false,

--- a/data/is-cfg.json
+++ b/data/is-cfg.json
@@ -75,9 +75,9 @@
 		"password": "",
 		"topic": "LoraAPRS/Data",
 		"will_active": false,
-        "will_topic": "LoraAPRS/State",
-        "will_message": "offline",
-        "birth_message": "online"
+		"will_topic": "LoraAPRS/State",
+		"will_message": "offline",
+		"birth_message": "online"
 	},
 	"syslog": {
 		"active": false,

--- a/src/project_configuration.cpp
+++ b/src/project_configuration.cpp
@@ -97,6 +97,13 @@ void ProjectConfigurationManagement::readProjectConfiguration(DynamicJsonDocumen
     conf.mqtt.password = data["mqtt"]["password"].as<String>();
   if (data["mqtt"].containsKey("topic"))
     conf.mqtt.topic = data["mqtt"]["topic"].as<String>();
+  conf.mqtt.will_active = data["mqtt"]["will_active"] | false;
+  if (data["mqtt"].containsKey("will_topic"))
+    conf.mqtt.will_topic = data["mqtt"]["will_topic"].as<String>();
+  if (data["mqtt"].containsKey("will_message"))
+    conf.mqtt.will_message = data["mqtt"]["will_message"].as<String>();
+  if (data["mqtt"].containsKey("birth_message"))
+    conf.mqtt.birth_message = data["mqtt"]["birth_message"].as<String>();
 
   conf.syslog.active = data["syslog"]["active"] | true;
   if (data["syslog"].containsKey("server"))
@@ -161,16 +168,19 @@ void ProjectConfigurationManagement::writeProjectConfiguration(Configuration &co
     v["name"]     = u.name;
     v["password"] = u.password;
   }
-  data["mqtt"]["active"]   = conf.mqtt.active;
-  data["mqtt"]["server"]   = conf.mqtt.server;
-  data["mqtt"]["port"]     = conf.mqtt.port;
-  data["mqtt"]["name"]     = conf.mqtt.name;
-  data["mqtt"]["password"] = conf.mqtt.password;
-  data["mqtt"]["topic"]    = conf.mqtt.topic;
-  data["syslog"]["active"] = conf.syslog.active;
-  data["syslog"]["server"] = conf.syslog.server;
-  data["syslog"]["port"]   = conf.syslog.port;
-  data["ntp_server"]       = conf.ntpServer;
+  data["mqtt"]["active"]        = conf.mqtt.active;
+  data["mqtt"]["server"]        = conf.mqtt.server;
+  data["mqtt"]["port"]          = conf.mqtt.port;
+  data["mqtt"]["name"]          = conf.mqtt.name;
+  data["mqtt"]["password"]      = conf.mqtt.password;
+  data["mqtt"]["topic"]         = conf.mqtt.topic;
+  data["mqtt"]["will_active"]   = conf.mqtt.will_active;
+  data["mqtt"]["will_topic"]    = conf.mqtt.will_topic;
+  data["mqtt"]["birth_message"] = conf.mqtt.birth_message;
+  data["syslog"]["active"]      = conf.syslog.active;
+  data["syslog"]["server"]      = conf.syslog.server;
+  data["syslog"]["port"]        = conf.syslog.port;
+  data["ntp_server"]            = conf.ntpServer;
 
   data["board"] = conf.board;
 }

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -131,9 +131,9 @@ public:
     String password;
     String topic;
     bool   will_active;
-		String will_topic;
-		String will_message;
-		String birth_message;
+    String will_topic;
+    String will_message;
+    String birth_message;
   };
 
   class Syslog {

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -121,7 +121,7 @@ public:
 
   class MQTT {
   public:
-    MQTT() : active(false), server(""), port(1883), name(""), password(""), topic("LoraAPRS/Data") {
+    MQTT() : active(false), server(""), port(1883), name(""), password(""), topic("LoraAPRS/Data"), will_active(false), will_topic("LoraAPRS/State"), will_message("offline"),birth_message("online") {
     }
 
     bool   active;
@@ -130,6 +130,10 @@ public:
     String name;
     String password;
     String topic;
+    bool   will_active;
+		String will_topic;
+		String will_message;
+		String birth_message;
   };
 
   class Syslog {

--- a/src/project_configuration.h
+++ b/src/project_configuration.h
@@ -121,7 +121,7 @@ public:
 
   class MQTT {
   public:
-    MQTT() : active(false), server(""), port(1883), name(""), password(""), topic("LoraAPRS/Data"), will_active(false), will_topic("LoraAPRS/State"), will_message("offline"),birth_message("online") {
+    MQTT() : active(false), server(""), port(1883), name(""), password(""), topic("LoraAPRS/Data"), will_active(false), will_topic("LoraAPRS/State"), will_message("offline"), birth_message("online") {
     }
 
     bool   active;


### PR DESCRIPTION
First, thanks a lot for this lovely piece of software. I'm only missing an antenna before I'll be able to put an iGate on the roof.

For me there was one important part missing. Some kind of trivial *monitoring* if the iGate is still working. MQTT has this nice feature of a *last will*, where the broker/server itself publishes to a topic as soon as the connection to the client is lost. This is how it works.

1. When connecting to MQTT we provide a last will topic and message. I use the message `offline`.
2. After connecting to MQTT send the birth message to the last will topic. I use `online`.
3. As long as the iGate is connected to MQTT the message will read `online`.
4. When the iGate looses the MQTT connection (for whatever reason), the MQTT broker changes the message to the one provided as *last will* which is `offline`.

Please note. The last will and birth messages do have the `retain` flag set. So the message is retained on the broker and always available.

Please consider to merge this change. I hope I was able to follow your coding style. It works fine for me since a few days and I'm quite happy with it even if I don't like the nesting in src/TaskMQTT.cpp MQTTTask::connect.

Feel free to modify whatever you don't like or discard this PR if it is not what you are looking for in this project.