### PR TITLE
restore option for ESPOTA - Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,9 @@ check_tool = cppcheck
 check_flags = cppcheck: --std=c++20 --suppress=*:*.pio\* --inline-suppr --suppress=unusedFunction -DCPPCHECK --force lib -ilib/TimeLib
 check_skip_packages = yes
 test_build_src = yes
+# activate for OTA Update, use the CALLSIGN from is-cfg.json as upload_port:
+#upload_protocol = espota
+#upload_port = <CALLSIGN>.local
 
 [env:lora_board]
 board = esp32doit-devkit-v1


### PR DESCRIPTION
This option was (mistakenly?) removed in commit #5c9317c