### PR TITLE
Bump espressif32 from 6.4.0 to 6.6.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = lora_board
 
 [env]
-platform = espressif32 @ 6.4.0
+platform = espressif32 @ 6.6.0
 framework = arduino
 lib_ldf_mode = deep+
 monitor_speed = 115200


### PR DESCRIPTION
Bump espressif32 from 6.4.0 to 6.6.0